### PR TITLE
feat: add logs for service updates

### DIFF
--- a/internal/manipulations/file.go
+++ b/internal/manipulations/file.go
@@ -35,5 +35,7 @@ func ChangeServiceTag(project, service, env, tag string) (bool, error) {
 		return false, err
 	}
 
+	fmt.Printf("Updating service %s to tag %s\n", service, tag)
+
 	return true, nil
 }


### PR DESCRIPTION
Right now promoting only logs when there are no changes to make. This change makes it so logs are printed even when services are updated properly, so the user understands what's going on.